### PR TITLE
Stream persist

### DIFF
--- a/Arkavo/Arkavo.xcodeproj/project.pbxproj
+++ b/Arkavo/Arkavo.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		DA78EF892C85FE4F00B89422 /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA78EF882C85FE4F00B89422 /* PersistenceController.swift */; };
 		DA8A058E2C43582200826542 /* PerformanceInfoOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8A058D2C43582200826542 /* PerformanceInfoOverlay.swift */; };
 		DA95A43A2C3DF611007409D5 /* City.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA95A4392C3DF60F007409D5 /* City.swift */; };
-		DA9D344A2C6AE68000D39ED4 /* StreamManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9D34492C6AE68000D39ED4 /* StreamManagementView.swift */; };
+		DA9D344A2C6AE68000D39ED4 /* StreamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9D34492C6AE68000D39ED4 /* StreamView.swift */; };
 		DABFC2902C34F54E00232D79 /* OpenTDFKit in Frameworks */ = {isa = PBXBuildFile; productRef = DABFC28F2C34F54E00232D79 /* OpenTDFKit */; };
 		DAC1F9E72C34DA7000499631 /* ArkavoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC1F9E62C34DA7000499631 /* ArkavoApp.swift */; };
 		DAC1F9E92C34DA7000499631 /* ArkavoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC1F9E82C34DA7000499631 /* ArkavoView.swift */; };
@@ -68,7 +68,7 @@
 		DA78EF882C85FE4F00B89422 /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
 		DA8A058D2C43582200826542 /* PerformanceInfoOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceInfoOverlay.swift; sourceTree = "<group>"; };
 		DA95A4392C3DF60F007409D5 /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
-		DA9D34492C6AE68000D39ED4 /* StreamManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamManagementView.swift; sourceTree = "<group>"; };
+		DA9D34492C6AE68000D39ED4 /* StreamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamView.swift; sourceTree = "<group>"; };
 		DAC1F9E32C34DA7000499631 /* Arkavo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Arkavo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAC1F9E62C34DA7000499631 /* ArkavoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkavoApp.swift; sourceTree = "<group>"; };
 		DAC1F9E82C34DA7000499631 /* ArkavoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkavoView.swift; sourceTree = "<group>"; };
@@ -142,8 +142,8 @@
 				DAC1F9E62C34DA7000499631 /* ArkavoApp.swift */,
 				DAC1F9E82C34DA7000499631 /* ArkavoView.swift */,
 				DA1A4DE22C69264F00722E3E /* AccountProfileView.swift */,
+				DA9D34492C6AE68000D39ED4 /* StreamView.swift */,
 				DA1A4DE42C6929CF00722E3E /* StreamProfileView.swift */,
-				DA9D34492C6AE68000D39ED4 /* StreamManagementView.swift */,
 				DA0FEC432C5B230700C0A010 /* ThoughtStreamView.swift */,
 				DA73B3342C6436EF00393056 /* WordCloudView.swift */,
 				DAF458A32C70320F004B44FE /* VideoStreamView.swift */,
@@ -331,7 +331,7 @@
 				DAC1F9E92C34DA7000499631 /* ArkavoView.swift in Sources */,
 				DA284D612C3F5AC300CCF7EC /* WebSocketManager.swift in Sources */,
 				DA1A4DE12C6807AD00722E3E /* Content.swift in Sources */,
-				DA9D344A2C6AE68000D39ED4 /* StreamManagementView.swift in Sources */,
+				DA9D344A2C6AE68000D39ED4 /* StreamView.swift in Sources */,
 				DAF458A42C70320F004B44FE /* VideoStreamView.swift in Sources */,
 				DA78EF892C85FE4F00B89422 /* PersistenceController.swift in Sources */,
 				DA03B4592C40AD9500C68162 /* AuthenticationManager.swift in Sources */,

--- a/Arkavo/Arkavo/Account.swift
+++ b/Arkavo/Arkavo/Account.swift
@@ -3,14 +3,32 @@ import SwiftData
 
 @Model
 final class Account {
-    @Attribute(.unique) let id: Int
-    var dateCreated: Date
+    @Attribute(.unique) var id: Int
     var profile: Profile?
     var authenticationToken: String?
-    // TODO: add Identity fields and authentication levels
+    var streams: [Stream] = []
+    var streamLimit: Int {
+        // TODO: handle feature payment for more
+        10
+    }
 
-    init() {
-        id = 0 // There should only ever be one account with id 0
-        dateCreated = Date()
+    init(id: Int = 0, profile: Profile? = nil, authenticationToken: String? = nil) {
+        self.id = id // There should only ever be one account with id 0
+        self.profile = profile
+        self.authenticationToken = authenticationToken
+    }
+
+    func addStream(_ stream: Stream) throws {
+        guard streams.count < streamLimit else {
+            throw StreamLimitError.exceededLimit
+        }
+        stream.account = self
+        streams.append(stream)
+    }
+
+    enum StreamLimitError: Error {
+        case exceededLimit
     }
 }
+
+// TODO: add Identity fields and authentication levels

--- a/Arkavo/Arkavo/ArkavoView.swift
+++ b/Arkavo/Arkavo/ArkavoView.swift
@@ -102,7 +102,7 @@ struct ArkavoView: View {
                         VideoStreamView(viewModel: videoStreamViewModel)
                     #endif
                 case .streams:
-                    StreamManagementView()
+                    StreamView()
                 }
                 if selectedView != .initial {
                     VStack {

--- a/Arkavo/Arkavo/PersistenceController.swift
+++ b/Arkavo/Arkavo/PersistenceController.swift
@@ -52,12 +52,6 @@ class PersistenceController {
 
     // MARK: - Profile Operations
 
-    func createProfile(name: String, blurb: String?) -> Profile {
-        let profile = Profile(name: name, blurb: blurb)
-        container.mainContext.insert(profile)
-        return profile
-    }
-
     func fetchProfile(withID id: UUID) throws -> Profile? {
         try container.mainContext.fetch(FetchDescriptor<Profile>(predicate: #Predicate { $0.id == id })).first
     }

--- a/Arkavo/Arkavo/Stream.swift
+++ b/Arkavo/Arkavo/Stream.swift
@@ -7,12 +7,29 @@ final class Stream: @unchecked Sendable {
     @Attribute(.unique) private(set) var id: UUID
     var account: Account
     var profile: Profile
+    var admissionPolicy: AdmissionPolicy
+    var interactionPolicy: InteractionPolicy
 
-    init(id: UUID = UUID(), account: Account, profile: Profile) {
+    init(id: UUID = UUID(), account: Account, profile: Profile, admissionPolicy: AdmissionPolicy, interactionPolicy: InteractionPolicy) {
         self.id = id
         self.account = account
         self.profile = profile
+        self.admissionPolicy = admissionPolicy
+        self.interactionPolicy = interactionPolicy
     }
+}
+
+enum AdmissionPolicy: String, Codable, CaseIterable {
+    case open = "Open"
+    case openInvitation = "Invitation"
+    case openApplication = "Application"
+    case closed = "Closed"
+}
+
+enum InteractionPolicy: String, Codable, CaseIterable {
+    case open = "Open"
+    case moderated = "Moderated"
+    case closed = "Closed"
 }
 
 extension Stream: AppEntity {

--- a/Arkavo/Arkavo/Stream.swift
+++ b/Arkavo/Arkavo/Stream.swift
@@ -1,20 +1,16 @@
 import AppIntents
 import Foundation
+import SwiftData
 
-final class Stream {
-    let id: UUID
-    var name: String
-    let createdAt: Date
-    var updatedAt: Date
-    var ownerUUID: UUID
+@Model
+final class Stream: @unchecked Sendable {
+    @Attribute(.unique) private(set) var id: UUID
+    var account: Account
     var profile: Profile
 
-    init(name: String, ownerUUID: UUID, profile: Profile) {
-        id = UUID()
-        self.name = name
-        createdAt = Date()
-        updatedAt = Date()
-        self.ownerUUID = ownerUUID
+    init(id: UUID = UUID(), account: Account, profile: Profile) {
+        self.id = id
+        self.account = account
         self.profile = profile
     }
 }
@@ -24,7 +20,7 @@ extension Stream: AppEntity {
     static var defaultQuery = StreamQuery()
 
     var displayRepresentation: DisplayRepresentation {
-        DisplayRepresentation(title: "\(name)")
+        DisplayRepresentation(title: "\(profile.name)")
     }
 
     static var typeDisplayName: String {

--- a/Arkavo/Arkavo/StreamProfileView.swift
+++ b/Arkavo/Arkavo/StreamProfileView.swift
@@ -1,103 +1,105 @@
+import SwiftData
 import SwiftUI
 
 struct CompactStreamProfileView: View {
-    @ObservedObject var viewModel: StreamProfileViewModel
+    @ObservedObject var viewModel: StreamViewModel
 
     var body: some View {
         HStack {
-            Text(viewModel.profile.name)
+            Text(viewModel.stream.profile.name)
                 .font(.headline)
             Spacer()
-            Text("Participants: \(viewModel.participantCount)")
-                .font(.subheadline)
         }
         .padding(.vertical, 8)
     }
 }
 
 struct DetailedStreamProfileView: View {
-    @ObservedObject var viewModel: StreamProfileViewModel
+    @ObservedObject var viewModel: StreamViewModel
 
     var body: some View {
         Form {
             Section(header: Text("Profile Information")) {
-                Text("Name: \(viewModel.profile.name)")
-                if let blurb = viewModel.profile.blurb {
-                    Text("Blurb: \(blurb)")
+                Text("\(viewModel.stream.profile.name)")
+                if let blurb = viewModel.stream.profile.blurb {
+                    Text("\(blurb)")
                 }
             }
-
-            Section(header: Text("Stream Information")) {
-                Text("Participants: \(viewModel.participantCount)")
-            }
-
-            Section(header: Text("Profile Details")) {
-                Text("ID: \(viewModel.profile.id.uuidString)")
-                Text("Created: \(viewModel.profile.dateCreated, formatter: DateFormatter.shortDateTime)")
+            Section(header: Text("Policies")) {
+                Text("Admission: \(viewModel.stream.admissionPolicy)")
+                Text("Interaction: \(viewModel.stream.interactionPolicy)")
             }
         }
         .navigationTitle("Stream Profile")
     }
 }
 
-class StreamProfileViewModel: ObservableObject {
-    @Published var profile: Profile
-    @Published var participantCount: Int
+class StreamViewModel: ObservableObject {
+    @Published var stream: Stream
 
-    init(profile: Profile, participantCount: Int) {
-        self.participantCount = participantCount
-        self.profile = profile
+    init(stream: Stream) {
+        self.stream = stream
     }
 }
 
 struct CreateStreamProfileView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel = CreateStreamProfileViewModel()
-    var onSave: (Profile, Int) -> Void
+    var onSave: (Profile, AdmissionPolicy, InteractionPolicy) -> Void
 
     var body: some View {
-        NavigationView {
+        VStack {
+            HStack {
+                Text("Create Stream")
+                    .font(.title)
+                    .padding(.leading, 16)
+                Spacer()
+                Button("Cancel") {
+                    dismiss()
+                }
+                .padding(.trailing, 16)
+            }
             Form {
-                Section(header: Text("Profile Information")) {
+                Section {
                     TextField("Name", text: $viewModel.name)
                     if !viewModel.nameError.isEmpty {
                         Text(viewModel.nameError).foregroundColor(.red)
                     }
-
-                    TextField("Blurb", text: $viewModel.blurb)
+                    TextField("Description", text: $viewModel.blurb)
                     if !viewModel.blurbError.isEmpty {
                         Text(viewModel.blurbError).foregroundColor(.red)
                     }
                 }
-
-                Section(header: Text("Stream Information")) {
-                    Stepper("Participants: \(viewModel.participantCount)", value: $viewModel.participantCount, in: 2 ... 100)
-                    if !viewModel.participantCountError.isEmpty {
-                        Text(viewModel.participantCountError).foregroundColor(.red)
-                    }
-                }
-            }
-            .navigationTitle("Create Stream")
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        dismiss()
-                    }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Create") {
-                        if let (profile, participantCount) = viewModel.createStreamProfile() {
-                            onSave(profile, participantCount)
-                            dismiss()
+                Section(header: Text("Policies")) {
+                    Picker("Admission", selection: $viewModel.admissionPolicy) {
+                        ForEach(AdmissionPolicy.allCases, id: \.self) { policy in
+                            Text(policy.rawValue).tag(policy)
                         }
                     }
-                    .disabled(!viewModel.isValid)
+                    Picker("Interaction", selection: $viewModel.interactionPolicy) {
+                        ForEach(InteractionPolicy.allCases, id: \.self) { policy in
+                            Text(policy.rawValue).tag(policy)
+                        }
+                    }
                 }
             }
+            Button(action: {
+                let profile = Profile(name: viewModel.name, blurb: viewModel.blurb)
+                onSave(profile, viewModel.admissionPolicy, viewModel.interactionPolicy)
+                dismiss()
+            }) {
+                Text("Save")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(viewModel.isValid ? Color.blue : Color.gray)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+            .padding()
+            .disabled(!viewModel.isValid)
         }
         .onChange(of: viewModel.name) { viewModel.validateName() }
         .onChange(of: viewModel.blurb) { viewModel.validateBlurb() }
-        .onChange(of: viewModel.participantCount) { viewModel.validateParticipantCount() }
     }
 }
 
@@ -105,9 +107,10 @@ class CreateStreamProfileViewModel: ObservableObject {
     @Published var name: String = ""
     @Published var blurb: String = ""
     @Published var participantCount: Int = 2
+    @Published var admissionPolicy: AdmissionPolicy = .open
+    @Published var interactionPolicy: InteractionPolicy = .open
     @Published var nameError: String = ""
     @Published var blurbError: String = ""
-    @Published var participantCountError: String = ""
     @Published var isValid: Bool = false
 
     func validateName() {
@@ -130,26 +133,67 @@ class CreateStreamProfileViewModel: ObservableObject {
         updateValidity()
     }
 
-    func validateParticipantCount() {
-        if participantCount < 2 {
-            participantCountError = "A Stream must have at least 2 participants"
-        } else if participantCount > 100 {
-            participantCountError = "A Stream can have at most 100 participants"
-        } else {
-            participantCountError = ""
-        }
-        updateValidity()
-    }
-
     private func updateValidity() {
-        isValid = nameError.isEmpty && blurbError.isEmpty && participantCountError.isEmpty && !name.isEmpty
+        isValid = nameError.isEmpty && blurbError.isEmpty && !name.isEmpty
     }
 
-    func createStreamProfile() -> (Profile, Int)? {
+    func createStreamProfile() -> (Profile, Int, AdmissionPolicy, InteractionPolicy)? {
         if isValid {
             let profile = Profile(name: name, blurb: blurb.isEmpty ? nil : blurb)
-            return (profile, participantCount)
+            return (profile, participantCount, admissionPolicy, interactionPolicy)
         }
         return nil
+    }
+}
+
+extension StreamProfileView_Previews {
+    static var previewStream: Stream {
+        let account = Account()
+        let profile = Profile(name: "Example Stream", blurb: "This is a sample stream for preview purposes.")
+        return Stream(account: account, profile: profile, admissionPolicy: .closed, interactionPolicy: .closed)
+    }
+}
+
+struct StreamProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            CompactStreamProfileView(viewModel: StreamViewModel(stream: previewStream))
+                .previewLayout(.sizeThatFits)
+                .previewDisplayName("Compact Stream Profile")
+
+            NavigationView {
+                DetailedStreamProfileView(viewModel: StreamViewModel(stream: previewStream))
+            }
+            .previewDisplayName("Detailed Stream Profile")
+
+            CreateStreamProfileView { _, _, _ in
+                // This closure is just for preview, so we'll leave it empty
+            }
+            .previewDisplayName("Create Stream Profile")
+        }
+        .modelContainer(previewContainer)
+    }
+
+    static var previewContainer: ModelContainer {
+        let schema = Schema([Account.self, Profile.self, Stream.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+
+        do {
+            let container = try ModelContainer(for: schema, configurations: [configuration])
+            let context = container.mainContext
+
+            // Create and save sample data
+            let account = Account()
+            try context.save()
+
+            let profile = Profile(name: "Example Stream", blurb: "This is a sample stream for preview purposes.")
+            let stream = Stream(account: account, profile: profile, admissionPolicy: .open, interactionPolicy: .open)
+            account.streams.append(stream)
+            try context.save()
+
+            return container
+        } catch {
+            fatalError("Failed to create preview container: \(error.localizedDescription)")
+        }
     }
 }

--- a/Arkavo/Arkavo/StreamView.swift
+++ b/Arkavo/Arkavo/StreamView.swift
@@ -5,32 +5,62 @@ import SwiftUI
 struct StreamView: View {
     @Query private var accounts: [Account]
     @State private var showingCreateStream = false
+    @State private var selectedStream: Stream?
 
     var body: some View {
-        List {
-            Section(header: Text("My Streams")) {
-                ForEach(accounts.first!.streams) { stream in
-                    CompactStreamProfileView(viewModel: StreamProfileViewModel(profile: stream.profile, participantCount: 2))
+        VStack {
+            Spacer(minLength: 40)
+            VStack {
+                HStack {
+                    Text("My Stream")
+                        .font(.title)
+                    Spacer()
                 }
-                .onDelete(perform: deleteStreams)
+                .padding()
+                List {
+                    Section(header:
+                        HStack {
+                            Text("Mine")
+                            Spacer()
+                            Button(action: {
+                                showingCreateStream = true
+                            }) {
+                                Image(systemName: "plus.circle")
+                                    .foregroundColor(.blue)
+                            }
+                        }
+                    ) {
+                        ForEach(accounts.first!.streams) { stream in
+                            CompactStreamProfileView(viewModel: StreamViewModel(stream: stream))
+                                .onTapGesture {
+                                    selectedStream = stream
+                                }
+                        }
+                        .onDelete(perform: deleteStreams)
+                    }
+                }
             }
-
-            Button("Create New Stream") {
-                showingCreateStream = true
+            .safeAreaInset(edge: .top) {
+                Color.clear.frame(height: 0)
             }
         }
-        .navigationTitle("My Streams")
         .sheet(isPresented: $showingCreateStream) {
-            CreateStreamProfileView { profile, _ in
-                createNewStream(with: profile)
+            CreateStreamProfileView { profile, admissionPolicy, interactionPolicy in
+                createNewStream(with: profile, admissionPolicy: admissionPolicy, interactionPolicy: interactionPolicy)
             }
+        }
+        .sheet(item: $selectedStream) { stream in
+            DetailedStreamProfileView(viewModel: StreamViewModel(stream: stream))
         }
     }
 
-    private func createNewStream(with streamProfile: Profile) {
+    private func createNewStream(with streamProfile: Profile, admissionPolicy: AdmissionPolicy, interactionPolicy: InteractionPolicy) {
+        guard let account = accounts.first else {
+            print("No account found")
+            return
+        }
         do {
-            let account = try PersistenceController.shared.getOrCreateAccount()
-            let stream = Stream(account: account, profile: streamProfile)
+            let stream = Stream(account: account, profile: streamProfile, admissionPolicy: admissionPolicy, interactionPolicy: interactionPolicy)
             try account.addStream(stream)
             try PersistenceController.shared.saveChanges()
         } catch {
@@ -38,32 +68,34 @@ struct StreamView: View {
         }
     }
 
-    private func deleteStreams(at _: IndexSet) {
-//        for index in offsets {
-//            let stream = streams[index]
-//            modelContext.delete(stream)
-//        }
-//        do {
-//            try modelContext.save()
-//        } catch {
-//            print("Failed to delete stream(s): \(error)")
-//        }
-        print("Failed to delete stream")
+    private func deleteStreams(at offsets: IndexSet) {
+        guard let account = accounts.first else {
+            print("No account found")
+            return
+        }
+        for offset in offsets {
+            if offset < account.streams.count {
+                account.streams.remove(at: offset)
+                do {
+                    try PersistenceController.shared.saveChanges()
+                } catch {
+                    print("Failed to delete stream(s): \(error)")
+                }
+            }
+        }
     }
 }
 
 struct StreamManagementView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            NavigationView {
-                StreamView()
-            }
-            .previewDisplayName("Main View")
+            StreamView()
+                .previewDisplayName("List Streams")
 
-            CreateStreamProfileView { _, _ in
+            CreateStreamProfileView { _, _, _ in
                 // This is just for preview, so we'll leave the closure empty
             }
-            .previewDisplayName("Create Stream Sheet")
+            .previewDisplayName("Create Stream")
         }
         .modelContainer(previewContainer)
     }
@@ -86,9 +118,9 @@ struct StreamManagementView_Previews: PreviewProvider {
                 Profile(name: "Stream 2", blurb: "This is the second stream"),
                 Profile(name: "Stream 3", blurb: "This is the third stream"),
             ]
-
+//            let profiles: [Profile] = []
             for profile in profiles {
-                let stream = Stream(account: account, profile: profile)
+                let stream = Stream(account: account, profile: profile, admissionPolicy: .open, interactionPolicy: .moderated)
                 account.streams.append(stream)
                 try context.save()
             }

--- a/Arkavo/Arkavo/StreamView.swift
+++ b/Arkavo/Arkavo/StreamView.swift
@@ -2,7 +2,7 @@ import CryptoKit
 import SwiftData
 import SwiftUI
 
-struct StreamManagementView: View {
+struct StreamView: View {
     @Query private var accounts: [Account]
     @State private var showingCreateStream = false
 
@@ -56,7 +56,7 @@ struct StreamManagementView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             NavigationView {
-                StreamManagementView()
+                StreamView()
             }
             .previewDisplayName("Main View")
 


### PR DESCRIPTION
Refactor Stream and Account models to use SwiftData and streamline their initializations. Simplify profile creation and handling in `PersistenceController` and update `StreamManagementView` and `ArkavoView` to align with these changes.

Introduced AdmissionPolicy and InteractionPolicy enums to manage stream access and interaction rules. Updated Stream and related views to incorporate these policies, enhancing the management and creation of streams.

Fixes #27 