### PR TITLE
Added Preprocessor flag for VisionOS fixed compile issue.

### DIFF
--- a/Arkavo/Arkavo/StreamProfileView.swift
+++ b/Arkavo/Arkavo/StreamProfileView.swift
@@ -54,7 +54,7 @@ struct DetailedStreamProfileView: View {
     }
 }
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     struct ShareSheet: UIViewControllerRepresentable {
         let activityItems: [Any]
         @Binding var isPresented: Bool


### PR DESCRIPTION
Added Preprocessor flag for vision OS. The needed code was skipped because only iOS and macOS cases were handled.