### PR TITLE
Receive Stream

### DIFF
--- a/Arkavo/Arkavo/ArkavoApp.swift
+++ b/Arkavo/Arkavo/ArkavoApp.swift
@@ -13,8 +13,10 @@ struct ArkavoApp: App {
         WindowGroup {
             NavigationStack(path: $navigationPath) {
                 ArkavoView()
+                #if os(iOS)
                     .navigationBarTitleDisplayMode(.inline)
                     .navigationBarHidden(true)
+                #endif
                     .modelContainer(persistenceController.container)
                     .task {
                         await ensureAccountExists()

--- a/Arkavo/Arkavo/ArkavoApp.swift
+++ b/Arkavo/Arkavo/ArkavoApp.swift
@@ -4,18 +4,40 @@ import SwiftUI
 @main
 struct ArkavoApp: App {
     @Environment(\.scenePhase) private var scenePhase
+    @State private var navigationPath = NavigationPath()
     let persistenceController = PersistenceController.shared
-
+    #if os(macOS)
+        @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    #endif
     var body: some Scene {
         WindowGroup {
-            ArkavoView()
-                .modelContainer(persistenceController.container)
-                .task {
-                    await ensureAccountExists()
+            NavigationStack(path: $navigationPath) {
+                ArkavoView()
+                    .modelContainer(persistenceController.container)
+                    .task {
+                        await ensureAccountExists()
+                    }
+                    .navigationDestination(for: DeepLinkDestination.self) { destination in
+                        switch destination {
+                        case let .stream(publicId):
+                            StreamLoadingView(publicId: publicId)
+                        case let .profile(publicId):
+                            // TODO: account profile
+                            Text("Profile View for \(publicId)")
+                        }
+                    }
+            }
+            .onOpenURL { url in
+                handleIncomingURL(url)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .handleIncomingURL)) { notification in
+                if let url = notification.object as? URL {
+                    handleIncomingURL(url)
                 }
+            }
             #if os(macOS)
-                .frame(minWidth: 800, idealWidth: 1200, maxWidth: .infinity,
-                       minHeight: 600, idealHeight: 800, maxHeight: .infinity)
+            .frame(minWidth: 800, idealWidth: 1200, maxWidth: .infinity,
+                   minHeight: 600, idealHeight: 800, maxHeight: .infinity)
             #endif
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -60,8 +82,134 @@ struct ArkavoApp: App {
             print("ArkavoApp: Error saving changes: \(error.localizedDescription)")
         }
     }
+
+    private func handleIncomingURL(_ url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+              components.host == "app.arkavo.com"
+        else {
+            print("Invalid URL format")
+            return
+        }
+
+        let pathComponents = components.path.split(separator: "/").map(String.init)
+
+        guard pathComponents.count == 2 else {
+            print("Invalid path format")
+            return
+        }
+
+        let type = pathComponents[0]
+        let publicId = pathComponents[1]
+
+        switch type {
+        case "stream":
+            navigationPath.append(DeepLinkDestination.stream(publicId: publicId))
+        case "profile":
+            navigationPath.append(DeepLinkDestination.profile(publicId: publicId))
+        default:
+            print("Unknown URL type")
+        }
+    }
+}
+
+struct StreamLoadingView: View {
+    let publicId: String
+    @State private var stream: Stream?
+    @State private var accountProfile: Profile?
+    @State private var isLoading = true
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView("Loading stream...")
+            } else if let stream {
+                let thoughtService = ThoughtService(ArkavoService())
+                let thoughtStreamViewModel = ThoughtStreamViewModel(service: thoughtService)
+                ThoughtStreamView(viewModel: thoughtStreamViewModel)
+                    .onAppear {
+                        thoughtStreamViewModel.stream = stream
+                        // FIXME: creatorProfile != accountProfile
+                        thoughtStreamViewModel.creatorProfile = accountProfile
+                        thoughtService.streamViewModel = StreamViewModel(thoughtStreamViewModel: thoughtStreamViewModel)
+                    }
+            } else {
+                Text("Stream not found")
+            }
+        }
+        .task {
+            await loadStream(withPublicId: publicId)
+        }
+    }
+
+    @MainActor
+    private func loadStream(withPublicId publicId: String) async {
+        isLoading = true
+        // Decode the hex-encoded publicId to Data
+        guard let publicIdData = Data(hexString: publicId) else {
+            print("Invalid publicId format")
+            stream = nil
+            isLoading = false
+            return
+        }
+
+        do {
+            let account = try await PersistenceController.shared.getOrCreateAccount()
+            accountProfile = account.profile
+            let streams = try await PersistenceController.shared.fetchStream(withPublicId: publicIdData)
+
+            if let stream = streams?.first {
+                print("Stream found with publicId: \(publicId)")
+                self.stream = stream
+                isLoading = false
+            } else {
+                print("No stream found with publicId: \(publicId)")
+                // Here you would typically implement logic to fetch the stream from a network source
+                // For now, we'll just return nil
+                isLoading = false
+            }
+        } catch {
+            print("Error fetching stream: \(error.localizedDescription)")
+            isLoading = false
+            return
+        }
+        isLoading = false
+    }
+}
+
+#if os(macOS)
+    class AppDelegate: NSObject, NSApplicationDelegate {
+        func application(_: NSApplication, open urls: [URL]) {
+            if let url = urls.first {
+                NotificationCenter.default.post(name: .handleIncomingURL, object: url)
+            }
+        }
+    }
+#endif
+
+enum DeepLinkDestination: Hashable {
+    case stream(publicId: String)
+    case profile(publicId: String)
 }
 
 extension Notification.Name {
     static let closeWebSockets = Notification.Name("CloseWebSockets")
+    static let handleIncomingURL = Notification.Name("HandleIncomingURL")
+}
+
+extension Data {
+    init?(hexString: String) {
+        let len = hexString.count / 2
+        var data = Data(capacity: len)
+        for i in 0 ..< len {
+            let j = hexString.index(hexString.startIndex, offsetBy: i * 2)
+            let k = hexString.index(j, offsetBy: 2)
+            let bytes = hexString[j ..< k]
+            if var num = UInt8(bytes, radix: 16) {
+                data.append(&num, count: 1)
+            } else {
+                return nil
+            }
+        }
+        self = data
+    }
 }

--- a/Arkavo/Arkavo/ArkavoApp.swift
+++ b/Arkavo/Arkavo/ArkavoApp.swift
@@ -13,6 +13,8 @@ struct ArkavoApp: App {
         WindowGroup {
             NavigationStack(path: $navigationPath) {
                 ArkavoView()
+                    .navigationBarTitleDisplayMode(.inline)
+                    .navigationBarHidden(true)
                     .modelContainer(persistenceController.container)
                     .task {
                         await ensureAccountExists()

--- a/Arkavo/Arkavo/PersistenceController.swift
+++ b/Arkavo/Arkavo/PersistenceController.swift
@@ -60,7 +60,12 @@ class PersistenceController {
 
     // MARK: - Stream Operations
 
-    func fetchStream(withID id: UUID) throws -> Stream? {
+    func fetchStream(withID id: UUID) async throws -> Stream? {
         try container.mainContext.fetch(FetchDescriptor<Stream>(predicate: #Predicate { $0.id == id })).first
+    }
+
+    func fetchStream(withPublicId publicId: Data) async throws -> [Stream]? {
+        let fetchDescriptor = FetchDescriptor<Stream>(predicate: #Predicate { $0.publicId == publicId })
+        return try container.mainContext.fetch(fetchDescriptor)
     }
 }

--- a/Arkavo/Localizable.xcstrings
+++ b/Arkavo/Localizable.xcstrings
@@ -221,6 +221,9 @@
         }
       }
     },
+    "Loading stream..." : {
+
+    },
     "Map" : {
       "localizations" : {
         "es-US" : {
@@ -350,6 +353,9 @@
           }
         }
       }
+    },
+    "Profile View for %@" : {
+
     },
     "Profile: %@" : {
       "localizations" : {
@@ -490,6 +496,9 @@
           }
         }
       }
+    },
+    "Stream not found" : {
+
     },
     "Streams" : {
       "localizations" : {


### PR DESCRIPTION
Add deep linking to handle URLs and display corresponding views

Enhanced the app to support deep linking by adding new logic to handle incoming URLs and route to appropriate views. Implemented URL parsing and added a new StreamLoadingView to display streams based on public IDs.

Note on macOS the AppDelegate does not receive the event for Universal Link handling