### PR TITLE
CacheEvent

### DIFF
--- a/Arkavo/Arkavo.xcodeproj/project.pbxproj
+++ b/Arkavo/Arkavo.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		DAC1F9FB2C34DA7100499631 /* ArkavoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC1F9FA2C34DA7100499631 /* ArkavoTests.swift */; };
 		DAC1FA052C34DA7100499631 /* ArkavoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC1FA042C34DA7100499631 /* ArkavoUITests.swift */; };
 		DAC1FA072C34DA7100499631 /* ArkavoUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC1FA062C34DA7100499631 /* ArkavoUITestsLaunchTests.swift */; };
+		DACCD61D2CAB91A600A9060C /* StreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACCD61C2CAB91A300A9060C /* StreamService.swift */; };
 		DAEE13872CA101D300DCB5EC /* EventServiceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEE13862CA101D300DCB5EC /* EventServiceModel.swift */; };
 		DAEE138A2CA1021500DCB5EC /* FlatBuffers in Frameworks */ = {isa = PBXBuildFile; productRef = DAEE13892CA1021500DCB5EC /* FlatBuffers */; };
 		DAF458A02C702AE0004B44FE /* VideoCaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF4589F2C702AE0004B44FE /* VideoCaptureManager.swift */; };
@@ -96,6 +97,7 @@
 		DAC1FA002C34DA7100499631 /* ArkavoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArkavoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAC1FA042C34DA7100499631 /* ArkavoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkavoUITests.swift; sourceTree = "<group>"; };
 		DAC1FA062C34DA7100499631 /* ArkavoUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkavoUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		DACCD61C2CAB91A300A9060C /* StreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamService.swift; sourceTree = "<group>"; };
 		DAEE13862CA101D300DCB5EC /* EventServiceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventServiceModel.swift; sourceTree = "<group>"; };
 		DAF4589F2C702AE0004B44FE /* VideoCaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCaptureManager.swift; sourceTree = "<group>"; };
 		DAF458A32C70320F004B44FE /* VideoStreamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoStreamView.swift; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 				DA73B3342C6436EF00393056 /* StreamCloudView.swift */,
 				DA1A4DE42C6929CF00722E3E /* StreamProfileView.swift */,
 				DA11D5192C8DDFA9005D1946 /* StreamMapView.swift */,
+				DACCD61C2CAB91A300A9060C /* StreamService.swift */,
 				DA7598BE2C95EE540021A8FC /* ThoughtService.swift */,
 				DA0FEC432C5B230700C0A010 /* ThoughtStreamView.swift */,
 				DAF458A32C70320F004B44FE /* VideoStreamView.swift */,
@@ -361,6 +364,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA179ADD2CA0C9360083EB99 /* UserAction.swift in Sources */,
+				DACCD61D2CAB91A600A9060C /* StreamService.swift in Sources */,
 				DA0FEC422C58766F00C0A010 /* Stream.swift in Sources */,
 				DA7598C52C9615F90021A8FC /* ArkavoPolicy.swift in Sources */,
 				DA7598BF2C95EE540021A8FC /* ThoughtService.swift in Sources */,

--- a/Arkavo/Arkavo/ArkavoApp.swift
+++ b/Arkavo/Arkavo/ArkavoApp.swift
@@ -1,4 +1,3 @@
-import FlatBuffers
 import SwiftData
 import SwiftUI
 
@@ -88,6 +87,7 @@ struct ArkavoApp: App {
         }
     }
 
+    // applinks
     private func handleIncomingURL(_ url: URL) {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
               components.host == "app.arkavo.com"

--- a/Arkavo/Arkavo/ArkavoService.swift
+++ b/Arkavo/Arkavo/ArkavoService.swift
@@ -12,6 +12,7 @@ class ArkavoService {
     let nanoTDFManager = NanoTDFManager()
     let authenticationManager = AuthenticationManager()
     var thoughtService: ThoughtService?
+    var streamService: StreamService?
     #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         var videoStreamViewModel: VideoStreamViewModel?
     #endif
@@ -23,6 +24,7 @@ class ArkavoService {
 
     func setupCallbacks() {
         thoughtService = ThoughtService(self)
+        streamService = StreamService(self)
         webSocketManager.setKASPublicKeyCallback { publicKey in
             if ArkavoService.kasPublicKey != nil {
                 return

--- a/Arkavo/Arkavo/ArkavoView.swift
+++ b/Arkavo/Arkavo/ArkavoView.swift
@@ -87,8 +87,10 @@ struct ArkavoView: View {
                         VideoStreamView(viewModel: videoStreamViewModel)
                     #endif
                 case .streamList:
-                    if let thoughtService = service.thoughtService {
-                        let thoughtStreamViewModel = ThoughtStreamViewModel(service: thoughtService)
+                    if let thoughtService = service.thoughtService,
+                       let streamService = service.streamService
+                    {
+                        let thoughtStreamViewModel = ThoughtStreamViewModel(thoughtService: thoughtService, streamService: streamService)
                         let streamViewModel = StreamViewModel(thoughtStreamViewModel: thoughtStreamViewModel)
                         StreamView(viewModel: streamViewModel)
                             .onAppear {

--- a/Arkavo/Arkavo/EventServiceModel.swift
+++ b/Arkavo/Arkavo/EventServiceModel.swift
@@ -8,17 +8,18 @@ public enum Arkavo_Action: Int8, Enum, Verifiable {
   public typealias T = Int8
   public static var byteSize: Int { return MemoryLayout<Int8>.size }
   public var value: Int8 { return self.rawValue }
-  case join = 0
-  case apply = 1
-  case approve = 2
-  case leave = 3
-  case cache = 4
-  case store = 5
-  case share = 6
-  case invite = 7
+  case unused = 0
+  case join = 1
+  case apply = 2
+  case approve = 3
+  case leave = 4
+  case cache = 5
+  case store = 6
+  case share = 7
+  case invite = 8
 
   public static var max: Arkavo_Action { return .invite }
-  public static var min: Arkavo_Action { return .join }
+  public static var min: Arkavo_Action { return .unused }
 }
 
 
@@ -26,13 +27,14 @@ public enum Arkavo_ActionStatus: Int8, Enum, Verifiable {
   public typealias T = Int8
   public static var byteSize: Int { return MemoryLayout<Int8>.size }
   public var value: Int8 { return self.rawValue }
-  case preparing = 0
-  case fulfilling = 1
-  case fulfilled = 2
-  case failed = 3
+  case unused = 0
+  case preparing = 1
+  case fulfilling = 2
+  case fulfilled = 3
+  case failed = 4
 
   public static var max: Arkavo_ActionStatus { return .failed }
-  public static var min: Arkavo_ActionStatus { return .preparing }
+  public static var min: Arkavo_ActionStatus { return .unused }
 }
 
 
@@ -40,11 +42,12 @@ public enum Arkavo_EntityType: Int8, Enum, Verifiable {
   public typealias T = Int8
   public static var byteSize: Int { return MemoryLayout<Int8>.size }
   public var value: Int8 { return self.rawValue }
-  case streamProfile = 0
-  case accountProfile = 1
+  case unused = 0
+  case streamProfile = 1
+  case accountProfile = 2
 
   public static var max: Arkavo_EntityType { return .accountProfile }
-  public static var min: Arkavo_EntityType { return .streamProfile }
+  public static var min: Arkavo_EntityType { return .unused }
 }
 
 
@@ -84,8 +87,8 @@ public struct Arkavo_UserEvent: FlatBufferObject, Verifiable {
     var p: VOffset { self.rawValue }
   }
 
-  public var sourceType: Arkavo_EntityType { let o = _accessor.offset(VTOFFSET.sourceType.v); return o == 0 ? .streamProfile : Arkavo_EntityType(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .streamProfile }
-  public var targetType: Arkavo_EntityType { let o = _accessor.offset(VTOFFSET.targetType.v); return o == 0 ? .streamProfile : Arkavo_EntityType(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .streamProfile }
+  public var sourceType: Arkavo_EntityType { let o = _accessor.offset(VTOFFSET.sourceType.v); return o == 0 ? .unused : Arkavo_EntityType(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unused }
+  public var targetType: Arkavo_EntityType { let o = _accessor.offset(VTOFFSET.targetType.v); return o == 0 ? .unused : Arkavo_EntityType(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unused }
   public var hasSourceId: Bool { let o = _accessor.offset(VTOFFSET.sourceId.v); return o == 0 ? false : true }
   public var sourceIdCount: Int32 { let o = _accessor.offset(VTOFFSET.sourceId.v); return o == 0 ? 0 : _accessor.vector(count: o) }
   public func sourceId(at index: Int32) -> UInt8 { let o = _accessor.offset(VTOFFSET.sourceId.v); return o == 0 ? 0 : _accessor.directRead(of: UInt8.self, offset: _accessor.vector(at: o) + index * 1) }
@@ -102,8 +105,8 @@ public struct Arkavo_UserEvent: FlatBufferObject, Verifiable {
   public static func endUserEvent(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createUserEvent(
     _ fbb: inout FlatBufferBuilder,
-    sourceType: Arkavo_EntityType = .streamProfile,
-    targetType: Arkavo_EntityType = .streamProfile,
+    sourceType: Arkavo_EntityType = .unused,
+    targetType: Arkavo_EntityType = .unused,
     sourceIdVectorOffset sourceId: Offset = Offset(),
     targetIdVectorOffset targetId: Offset = Offset()
   ) -> Offset {
@@ -204,9 +207,9 @@ public struct Arkavo_Event: FlatBufferObject, Verifiable {
     var p: VOffset { self.rawValue }
   }
 
-  public var action: Arkavo_Action { let o = _accessor.offset(VTOFFSET.action.v); return o == 0 ? .join : Arkavo_Action(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .join }
+  public var action: Arkavo_Action { let o = _accessor.offset(VTOFFSET.action.v); return o == 0 ? .unused : Arkavo_Action(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unused }
   public var timestamp: UInt64 { let o = _accessor.offset(VTOFFSET.timestamp.v); return o == 0 ? 0 : _accessor.readBuffer(of: UInt64.self, at: o) }
-  public var status: Arkavo_ActionStatus { let o = _accessor.offset(VTOFFSET.status.v); return o == 0 ? .preparing : Arkavo_ActionStatus(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .preparing }
+  public var status: Arkavo_ActionStatus { let o = _accessor.offset(VTOFFSET.status.v); return o == 0 ? .unused : Arkavo_ActionStatus(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .unused }
   public var dataType: Arkavo_EventData { let o = _accessor.offset(VTOFFSET.dataType.v); return o == 0 ? .none_ : Arkavo_EventData(rawValue: _accessor.readBuffer(of: UInt8.self, at: o)) ?? .none_ }
   public func data<T: FlatbuffersInitializable>(type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.data.v); return o == 0 ? nil : _accessor.union(o) }
   public static func startEvent(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 5) }
@@ -218,9 +221,9 @@ public struct Arkavo_Event: FlatBufferObject, Verifiable {
   public static func endEvent(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createEvent(
     _ fbb: inout FlatBufferBuilder,
-    action: Arkavo_Action = .join,
+    action: Arkavo_Action = .unused,
     timestamp: UInt64 = 0,
-    status: Arkavo_ActionStatus = .preparing,
+    status: Arkavo_ActionStatus = .unused,
     dataType: Arkavo_EventData = .none_,
     dataOffset data: Offset = Offset()
   ) -> Offset {

--- a/Arkavo/Arkavo/EventServiceModel.swift
+++ b/Arkavo/Arkavo/EventServiceModel.swift
@@ -4,7 +4,7 @@
 
 import FlatBuffers
 
-public enum Arkavo_ActionType: Int8, Enum, Verifiable {
+public enum Arkavo_Action: Int8, Enum, Verifiable {
   public typealias T = Int8
   public static var byteSize: Int { return MemoryLayout<Int8>.size }
   public var value: Int8 { return self.rawValue }
@@ -12,10 +12,13 @@ public enum Arkavo_ActionType: Int8, Enum, Verifiable {
   case apply = 1
   case approve = 2
   case leave = 3
-  case sendMessage = 4
+  case cache = 4
+  case store = 5
+  case share = 6
+  case invite = 7
 
-  public static var max: Arkavo_ActionType { return .sendMessage }
-  public static var min: Arkavo_ActionType { return .join }
+  public static var max: Arkavo_Action { return .invite }
+  public static var min: Arkavo_Action { return .join }
 }
 
 
@@ -45,40 +48,23 @@ public enum Arkavo_EntityType: Int8, Enum, Verifiable {
 }
 
 
-public struct Arkavo_Event: FlatBufferObject, Verifiable {
+public enum Arkavo_EventData: UInt8, UnionEnum {
+  public typealias T = UInt8
 
-  static func validateVersion() { FlatBuffersVersion_24_3_25() }
-  public var __buffer: ByteBuffer! { return _accessor.bb }
-  private var _accessor: Table
-
-  private init(_ t: Table) { _accessor = t }
-  public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
-
-  private enum VTOFFSET: VOffset {
-    case actionType = 4
-    var v: Int32 { Int32(self.rawValue) }
-    var p: VOffset { self.rawValue }
+  public init?(value: T) {
+    self.init(rawValue: value)
   }
 
-  public var actionType: Arkavo_ActionType { let o = _accessor.offset(VTOFFSET.actionType.v); return o == 0 ? .join : Arkavo_ActionType(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .join }
-  public static func startEvent(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-  public static func add(actionType: Arkavo_ActionType, _ fbb: inout FlatBufferBuilder) { fbb.add(element: actionType.rawValue, def: 0, at: VTOFFSET.actionType.p) }
-  public static func endEvent(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
-  public static func createEvent(
-    _ fbb: inout FlatBufferBuilder,
-    actionType: Arkavo_ActionType = .join
-  ) -> Offset {
-    let __start = Arkavo_Event.startEvent(&fbb)
-    Arkavo_Event.add(actionType: actionType, &fbb)
-    return Arkavo_Event.endEvent(&fbb, start: __start)
-  }
+  public static var byteSize: Int { return MemoryLayout<UInt8>.size }
+  public var value: UInt8 { return self.rawValue }
+  case none_ = 0
+  case userevent = 1
+  case cacheevent = 2
 
-  public static func verify<T>(_ verifier: inout Verifier, at position: Int, of type: T.Type) throws where T: Verifiable {
-    var _v = try verifier.visitTable(at: position)
-    try _v.visit(field: VTOFFSET.actionType.p, fieldName: "actionType", required: false, type: Arkavo_ActionType.self)
-    _v.finish()
-  }
+  public static var max: Arkavo_EventData { return .cacheevent }
+  public static var min: Arkavo_EventData { return .none_ }
 }
+
 
 public struct Arkavo_UserEvent: FlatBufferObject, Verifiable {
 
@@ -94,8 +80,6 @@ public struct Arkavo_UserEvent: FlatBufferObject, Verifiable {
     case targetType = 6
     case sourceId = 8
     case targetId = 10
-    case timestamp = 12
-    case status = 14
     var v: Int32 { Int32(self.rawValue) }
     var p: VOffset { self.rawValue }
   }
@@ -110,32 +94,24 @@ public struct Arkavo_UserEvent: FlatBufferObject, Verifiable {
   public var targetIdCount: Int32 { let o = _accessor.offset(VTOFFSET.targetId.v); return o == 0 ? 0 : _accessor.vector(count: o) }
   public func targetId(at index: Int32) -> UInt8 { let o = _accessor.offset(VTOFFSET.targetId.v); return o == 0 ? 0 : _accessor.directRead(of: UInt8.self, offset: _accessor.vector(at: o) + index * 1) }
   public var targetId: [UInt8] { return _accessor.getVector(at: VTOFFSET.targetId.v) ?? [] }
-  public var timestamp: UInt64 { let o = _accessor.offset(VTOFFSET.timestamp.v); return o == 0 ? 0 : _accessor.readBuffer(of: UInt64.self, at: o) }
-  public var status: Arkavo_ActionStatus { let o = _accessor.offset(VTOFFSET.status.v); return o == 0 ? .preparing : Arkavo_ActionStatus(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .preparing }
-  public static func startUserEvent(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 6) }
+  public static func startUserEvent(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 4) }
   public static func add(sourceType: Arkavo_EntityType, _ fbb: inout FlatBufferBuilder) { fbb.add(element: sourceType.rawValue, def: 0, at: VTOFFSET.sourceType.p) }
   public static func add(targetType: Arkavo_EntityType, _ fbb: inout FlatBufferBuilder) { fbb.add(element: targetType.rawValue, def: 0, at: VTOFFSET.targetType.p) }
   public static func addVectorOf(sourceId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: sourceId, at: VTOFFSET.sourceId.p) }
   public static func addVectorOf(targetId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: targetId, at: VTOFFSET.targetId.p) }
-  public static func add(timestamp: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: timestamp, def: 0, at: VTOFFSET.timestamp.p) }
-  public static func add(status: Arkavo_ActionStatus, _ fbb: inout FlatBufferBuilder) { fbb.add(element: status.rawValue, def: 0, at: VTOFFSET.status.p) }
   public static func endUserEvent(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createUserEvent(
     _ fbb: inout FlatBufferBuilder,
     sourceType: Arkavo_EntityType = .streamProfile,
     targetType: Arkavo_EntityType = .streamProfile,
     sourceIdVectorOffset sourceId: Offset = Offset(),
-    targetIdVectorOffset targetId: Offset = Offset(),
-    timestamp: UInt64 = 0,
-    status: Arkavo_ActionStatus = .preparing
+    targetIdVectorOffset targetId: Offset = Offset()
   ) -> Offset {
     let __start = Arkavo_UserEvent.startUserEvent(&fbb)
     Arkavo_UserEvent.add(sourceType: sourceType, &fbb)
     Arkavo_UserEvent.add(targetType: targetType, &fbb)
     Arkavo_UserEvent.addVectorOf(sourceId: sourceId, &fbb)
     Arkavo_UserEvent.addVectorOf(targetId: targetId, &fbb)
-    Arkavo_UserEvent.add(timestamp: timestamp, &fbb)
-    Arkavo_UserEvent.add(status: status, &fbb)
     return Arkavo_UserEvent.endUserEvent(&fbb, start: __start)
   }
 
@@ -145,8 +121,133 @@ public struct Arkavo_UserEvent: FlatBufferObject, Verifiable {
     try _v.visit(field: VTOFFSET.targetType.p, fieldName: "targetType", required: false, type: Arkavo_EntityType.self)
     try _v.visit(field: VTOFFSET.sourceId.p, fieldName: "sourceId", required: false, type: ForwardOffset<Vector<UInt8, UInt8>>.self)
     try _v.visit(field: VTOFFSET.targetId.p, fieldName: "targetId", required: false, type: ForwardOffset<Vector<UInt8, UInt8>>.self)
+    _v.finish()
+  }
+}
+
+public struct Arkavo_CacheEvent: FlatBufferObject, Verifiable {
+
+  static func validateVersion() { FlatBuffersVersion_24_3_25() }
+  public var __buffer: ByteBuffer! { return _accessor.bb }
+  private var _accessor: Table
+
+  private init(_ t: Table) { _accessor = t }
+  public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
+
+  private enum VTOFFSET: VOffset {
+    case targetId = 4
+    case targetPayload = 6
+    case ttl = 8
+    case oneTimeAccess = 10
+    var v: Int32 { Int32(self.rawValue) }
+    var p: VOffset { self.rawValue }
+  }
+
+  public var hasTargetId: Bool { let o = _accessor.offset(VTOFFSET.targetId.v); return o == 0 ? false : true }
+  public var targetIdCount: Int32 { let o = _accessor.offset(VTOFFSET.targetId.v); return o == 0 ? 0 : _accessor.vector(count: o) }
+  public func targetId(at index: Int32) -> UInt8 { let o = _accessor.offset(VTOFFSET.targetId.v); return o == 0 ? 0 : _accessor.directRead(of: UInt8.self, offset: _accessor.vector(at: o) + index * 1) }
+  public var targetId: [UInt8] { return _accessor.getVector(at: VTOFFSET.targetId.v) ?? [] }
+  public var hasTargetPayload: Bool { let o = _accessor.offset(VTOFFSET.targetPayload.v); return o == 0 ? false : true }
+  public var targetPayloadCount: Int32 { let o = _accessor.offset(VTOFFSET.targetPayload.v); return o == 0 ? 0 : _accessor.vector(count: o) }
+  public func targetPayload(at index: Int32) -> UInt8 { let o = _accessor.offset(VTOFFSET.targetPayload.v); return o == 0 ? 0 : _accessor.directRead(of: UInt8.self, offset: _accessor.vector(at: o) + index * 1) }
+  public var targetPayload: [UInt8] { return _accessor.getVector(at: VTOFFSET.targetPayload.v) ?? [] }
+  public var ttl: UInt32 { let o = _accessor.offset(VTOFFSET.ttl.v); return o == 0 ? 0 : _accessor.readBuffer(of: UInt32.self, at: o) }
+  public var oneTimeAccess: Bool { let o = _accessor.offset(VTOFFSET.oneTimeAccess.v); return o == 0 ? false : _accessor.readBuffer(of: Bool.self, at: o) }
+  public static func startCacheEvent(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 4) }
+  public static func addVectorOf(targetId: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: targetId, at: VTOFFSET.targetId.p) }
+  public static func addVectorOf(targetPayload: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: targetPayload, at: VTOFFSET.targetPayload.p) }
+  public static func add(ttl: UInt32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: ttl, def: 0, at: VTOFFSET.ttl.p) }
+  public static func add(oneTimeAccess: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: oneTimeAccess, def: false,
+   at: VTOFFSET.oneTimeAccess.p) }
+  public static func endCacheEvent(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
+  public static func createCacheEvent(
+    _ fbb: inout FlatBufferBuilder,
+    targetIdVectorOffset targetId: Offset = Offset(),
+    targetPayloadVectorOffset targetPayload: Offset = Offset(),
+    ttl: UInt32 = 0,
+    oneTimeAccess: Bool = false
+  ) -> Offset {
+    let __start = Arkavo_CacheEvent.startCacheEvent(&fbb)
+    Arkavo_CacheEvent.addVectorOf(targetId: targetId, &fbb)
+    Arkavo_CacheEvent.addVectorOf(targetPayload: targetPayload, &fbb)
+    Arkavo_CacheEvent.add(ttl: ttl, &fbb)
+    Arkavo_CacheEvent.add(oneTimeAccess: oneTimeAccess, &fbb)
+    return Arkavo_CacheEvent.endCacheEvent(&fbb, start: __start)
+  }
+
+  public static func verify<T>(_ verifier: inout Verifier, at position: Int, of type: T.Type) throws where T: Verifiable {
+    var _v = try verifier.visitTable(at: position)
+    try _v.visit(field: VTOFFSET.targetId.p, fieldName: "targetId", required: false, type: ForwardOffset<Vector<UInt8, UInt8>>.self)
+    try _v.visit(field: VTOFFSET.targetPayload.p, fieldName: "targetPayload", required: false, type: ForwardOffset<Vector<UInt8, UInt8>>.self)
+    try _v.visit(field: VTOFFSET.ttl.p, fieldName: "ttl", required: false, type: UInt32.self)
+    try _v.visit(field: VTOFFSET.oneTimeAccess.p, fieldName: "oneTimeAccess", required: false, type: Bool.self)
+    _v.finish()
+  }
+}
+
+public struct Arkavo_Event: FlatBufferObject, Verifiable {
+
+  static func validateVersion() { FlatBuffersVersion_24_3_25() }
+  public var __buffer: ByteBuffer! { return _accessor.bb }
+  private var _accessor: Table
+
+  private init(_ t: Table) { _accessor = t }
+  public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
+
+  private enum VTOFFSET: VOffset {
+    case action = 4
+    case timestamp = 6
+    case status = 8
+    case dataType = 10
+    case data = 12
+    var v: Int32 { Int32(self.rawValue) }
+    var p: VOffset { self.rawValue }
+  }
+
+  public var action: Arkavo_Action { let o = _accessor.offset(VTOFFSET.action.v); return o == 0 ? .join : Arkavo_Action(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .join }
+  public var timestamp: UInt64 { let o = _accessor.offset(VTOFFSET.timestamp.v); return o == 0 ? 0 : _accessor.readBuffer(of: UInt64.self, at: o) }
+  public var status: Arkavo_ActionStatus { let o = _accessor.offset(VTOFFSET.status.v); return o == 0 ? .preparing : Arkavo_ActionStatus(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .preparing }
+  public var dataType: Arkavo_EventData { let o = _accessor.offset(VTOFFSET.dataType.v); return o == 0 ? .none_ : Arkavo_EventData(rawValue: _accessor.readBuffer(of: UInt8.self, at: o)) ?? .none_ }
+  public func data<T: FlatbuffersInitializable>(type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.data.v); return o == 0 ? nil : _accessor.union(o) }
+  public static func startEvent(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 5) }
+  public static func add(action: Arkavo_Action, _ fbb: inout FlatBufferBuilder) { fbb.add(element: action.rawValue, def: 0, at: VTOFFSET.action.p) }
+  public static func add(timestamp: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: timestamp, def: 0, at: VTOFFSET.timestamp.p) }
+  public static func add(status: Arkavo_ActionStatus, _ fbb: inout FlatBufferBuilder) { fbb.add(element: status.rawValue, def: 0, at: VTOFFSET.status.p) }
+  public static func add(dataType: Arkavo_EventData, _ fbb: inout FlatBufferBuilder) { fbb.add(element: dataType.rawValue, def: 0, at: VTOFFSET.dataType.p) }
+  public static func add(data: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: data, at: VTOFFSET.data.p) }
+  public static func endEvent(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
+  public static func createEvent(
+    _ fbb: inout FlatBufferBuilder,
+    action: Arkavo_Action = .join,
+    timestamp: UInt64 = 0,
+    status: Arkavo_ActionStatus = .preparing,
+    dataType: Arkavo_EventData = .none_,
+    dataOffset data: Offset = Offset()
+  ) -> Offset {
+    let __start = Arkavo_Event.startEvent(&fbb)
+    Arkavo_Event.add(action: action, &fbb)
+    Arkavo_Event.add(timestamp: timestamp, &fbb)
+    Arkavo_Event.add(status: status, &fbb)
+    Arkavo_Event.add(dataType: dataType, &fbb)
+    Arkavo_Event.add(data: data, &fbb)
+    return Arkavo_Event.endEvent(&fbb, start: __start)
+  }
+
+  public static func verify<T>(_ verifier: inout Verifier, at position: Int, of type: T.Type) throws where T: Verifiable {
+    var _v = try verifier.visitTable(at: position)
+    try _v.visit(field: VTOFFSET.action.p, fieldName: "action", required: false, type: Arkavo_Action.self)
     try _v.visit(field: VTOFFSET.timestamp.p, fieldName: "timestamp", required: false, type: UInt64.self)
     try _v.visit(field: VTOFFSET.status.p, fieldName: "status", required: false, type: Arkavo_ActionStatus.self)
+    try _v.visit(unionKey: VTOFFSET.dataType.p, unionField: VTOFFSET.data.p, unionKeyName: "dataType", fieldName: "data", required: false, completion: { (verifier, key: Arkavo_EventData, pos) in
+      switch key {
+      case .none_:
+        break // NOTE - SWIFT doesnt support none
+      case .userevent:
+        try ForwardOffset<Arkavo_UserEvent>.verify(&verifier, at: pos, of: Arkavo_UserEvent.self)
+      case .cacheevent:
+        try ForwardOffset<Arkavo_CacheEvent>.verify(&verifier, at: pos, of: Arkavo_CacheEvent.self)
+      }
+    })
     _v.finish()
   }
 }

--- a/Arkavo/Arkavo/Extension.swift
+++ b/Arkavo/Arkavo/Extension.swift
@@ -105,6 +105,10 @@ extension Data {
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
     }
+
+    func hexEncodedString() -> String {
+        map { String(format: "%02hhx", $0) }.joined()
+    }
 }
 
 extension String {

--- a/Arkavo/Arkavo/Extension.swift
+++ b/Arkavo/Arkavo/Extension.swift
@@ -138,4 +138,8 @@ extension String {
         }
         return base64
     }
+
+    var base58Decoded: Data? {
+        Data(base58Encoded: self)
+    }
 }

--- a/Arkavo/Arkavo/Extension.swift
+++ b/Arkavo/Arkavo/Extension.swift
@@ -38,12 +38,11 @@ extension Data {
 
 enum Base58 {
     private static let alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-    private static let baseCount = UInt8(alphabet.count)
+    private static let base = alphabet.count
 
     static func encode(_ bytes: [UInt8]) -> String {
         var bytes = bytes
         var zerosCount = 0
-        var length = 0
 
         for b in bytes {
             if b != 0 { break }
@@ -52,71 +51,50 @@ enum Base58 {
 
         bytes.removeFirst(zerosCount)
 
-        let size = bytes.count * 138 / 100 + 1
-
-        var base58: [UInt8] = Array(repeating: 0, count: size)
+        var result = [UInt8]()
         for b in bytes {
             var carry = Int(b)
-            var i = 0
-
-            for j in 0 ... base58.count - 1 where carry != 0 || i < length {
-                carry += 256 * Int(base58[base58.count - 1 - j])
-                base58[base58.count - 1 - j] = UInt8(carry % 58)
-                carry /= 58
-                i += 1
+            for j in 0 ..< result.count {
+                carry += Int(result[j]) << 8
+                result[j] = UInt8(carry % base)
+                carry /= base
             }
-
-            assert(carry == 0)
-
-            length = i
+            while carry > 0 {
+                result.append(UInt8(carry % base))
+                carry /= base
+            }
         }
 
-        var string = ""
-        for _ in 0 ..< zerosCount {
-            string += "1"
-        }
-
-        for b in base58[base58.count - length ..< base58.count].reversed() {
-            string += String(alphabet[alphabet.index(alphabet.startIndex, offsetBy: Int(b))])
-        }
-
-        return string
+        let prefix = String(repeating: alphabet.first!, count: zerosCount)
+        let encoded = result.reversed().map { alphabet[alphabet.index(alphabet.startIndex, offsetBy: Int($0))] }
+        return prefix + String(encoded)
     }
 
-    static func decode(_ base58: String) -> [UInt8]? {
+    static func decode(_ string: String) -> [UInt8]? {
         var result = [UInt8]()
-        var leadingZeros = 0
-        var value: UInt = 0
-        var base: UInt = 1
+        for char in string {
+            guard let charIndex = alphabet.firstIndex(of: char) else { return nil }
+            let index = alphabet.distance(from: alphabet.startIndex, to: charIndex)
 
-        for char in base58.reversed() {
-            guard let digit = alphabet.firstIndex(of: char) else { return nil }
-            let index = alphabet.distance(from: alphabet.startIndex, to: digit)
-            value += UInt(index) * base
-            base *= UInt(baseCount)
+            var carry = index
+            for j in 0 ..< result.count {
+                carry += Int(result[j]) * base
+                result[j] = UInt8(carry & 0xFF)
+                carry >>= 8
+            }
 
-            if value > UInt(UInt8.max) {
-                var mod = value
-                while mod > 0 {
-                    result.insert(UInt8(mod & 0xFF), at: 0)
-                    mod >>= 8
-                }
-                value = 0
-                base = 1
+            while carry > 0 {
+                result.append(UInt8(carry & 0xFF))
+                carry >>= 8
             }
         }
 
-        if value > 0 {
-            result.insert(UInt8(value), at: 0)
+        for char in string {
+            if char != alphabet.first! { break }
+            result.append(0)
         }
 
-        for char in base58 {
-            guard char == "1" else { break }
-            leadingZeros += 1
-        }
-
-        result.insert(contentsOf: repeatElement(0, count: leadingZeros), at: 0)
-        return result
+        return result.reversed()
     }
 }
 

--- a/Arkavo/Arkavo/PersistenceController.swift
+++ b/Arkavo/Arkavo/PersistenceController.swift
@@ -9,27 +9,6 @@ class PersistenceController {
     let container: ModelContainer
 
     private init() {
-        // Create a FlatBuffer builder
-        var builder = FlatBufferBuilder(initialSize: 1024)
-        // Create string offsets
-        let sourcePublicID: [UInt8] = [1, 2, 3, 4, 5] // Example byte array for sourcePublicID
-        let targetPublicID: [UInt8] = [6, 7, 8, 9, 10] // Example byte array for targetPublicID
-        let sourcePublicIDOffset = builder.createVector(sourcePublicID)
-        let targetPublicIDOffset = builder.createVector(targetPublicID)
-        // Create the Event object in the FlatBuffer
-        let action = Arkavo_UserEvent.createUserEvent(
-            &builder,
-            sourceType: .accountProfile,
-            targetType: .streamProfile,
-            sourceIdVectorOffset: sourcePublicIDOffset,
-            targetIdVectorOffset: targetPublicIDOffset,
-            timestamp: UInt64(Date().timeIntervalSince1970),
-            status: .preparing
-        )
-        builder.finish(offset: action)
-        let data = builder.data
-        let serializedEvent = data.base64EncodedString()
-        print("streamJoinUsepublicrEvent: \(serializedEvent)")
         do {
             let schema = Schema([
                 Account.self,

--- a/Arkavo/Arkavo/PersistenceController.swift
+++ b/Arkavo/Arkavo/PersistenceController.swift
@@ -1,4 +1,3 @@
-import FlatBuffers
 import Foundation
 import SwiftData
 

--- a/Arkavo/Arkavo/StreamService.swift
+++ b/Arkavo/Arkavo/StreamService.swift
@@ -1,0 +1,151 @@
+import CryptoKit
+import FlatBuffers
+import Foundation
+import OpenTDFKit
+import SwiftData
+
+struct StreamServiceModel: Codable {
+    var publicID: Data
+    var streamProfile: Profile
+    var admissionPolicy: AdmissionPolicy
+    var interactionPolicy: InteractionPolicy
+
+    init(stream: Stream) {
+        publicID = stream.publicID
+        streamProfile = stream.profile
+        admissionPolicy = .open
+        interactionPolicy = .open
+    }
+}
+
+extension StreamServiceModel {
+    private static let decoder = PropertyListDecoder()
+    private static let encoder: PropertyListEncoder = {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        return encoder
+    }()
+
+    var publicIDString: String {
+        publicID.base58EncodedString
+    }
+
+    func serialize() throws -> Data {
+        try StreamServiceModel.encoder.encode(self)
+    }
+
+    static func deserialize(from data: Data) throws -> StreamServiceModel {
+        try decoder.decode(StreamServiceModel.self, from: data)
+    }
+}
+
+class StreamService {
+    private let service: ArkavoService
+    public var streamViewModel: StreamViewModel?
+
+    init(_ service: ArkavoService) {
+        self.service = service
+    }
+
+    @MainActor func createStream(_ viewModel: StreamViewModel) throws -> Data {
+        guard let kasPublicKey = ArkavoService.kasPublicKey else {
+            print("KAS public key not available")
+            return Data()
+        }
+
+        let payload = try createPayload(viewModel: viewModel)
+
+        let kasRL = ResourceLocator(protocolEnum: .sharedResourceDirectory, body: "kas.arkavo.net")!
+        let kasMetadata = KasMetadata(resourceLocator: kasRL, publicKey: kasPublicKey, curve: .secp256r1)
+        let remotePolicy = ResourceLocator(protocolEnum: .sharedResourceDirectory, body: "5GnJAVumy3NBdo2u9ZEK1MQAXdiVnZWzzso4diP2JszVgSJQ")!
+        var policy = Policy(type: .remote, body: nil, remote: remotePolicy, binding: nil)
+
+        let nanoTDF = try createNanoTDF(kas: kasMetadata, policy: &policy, plaintext: payload)
+        return nanoTDF.toData()
+    }
+
+    @MainActor func createPayload(viewModel: StreamViewModel) throws -> Data {
+        guard let stream = viewModel.thoughtStreamViewModel.stream else {
+            throw StreamServiceError.missingAccountOrProfile
+        }
+        let streamServiceModel = StreamServiceModel(stream: stream)
+        let payload = try streamServiceModel.serialize()
+        return payload
+    }
+
+    func sendStream(_ nano: Data) throws {
+        let natsMessage = NATSMessage(payload: nano)
+        let messageData = natsMessage.toData()
+
+        WebSocketManager.shared.sendCustomMessage(messageData) { error in
+            if let error {
+                print("Error sending stream: \(error)")
+            }
+        }
+    }
+
+    func sendEvent(_ payload: Data) throws {
+        let natsMessage = NATSEvent(payload: payload)
+        let messageData = natsMessage.toData()
+        print("Sending event: \(messageData)")
+        WebSocketManager.shared.sendCustomMessage(messageData) { error in
+            if let error {
+                print("Error sending stream: \(error)")
+            }
+        }
+    }
+
+    @MainActor
+    public func fetchStream(withPublicID publicID: Data) async throws -> Stream? {
+        let streams = try await PersistenceController.shared.fetchStream(withPublicID: publicID)
+        let stream = streams?.first
+        if stream == nil {
+            print("No stream found with publicID: \(publicID)")
+            // get stream
+            var builder = FlatBufferBuilder(initialSize: 1024)
+            // Create string offsets
+            let targetIdVector = builder.createVector(bytes: publicID)
+            let sourcePublicID: [UInt8] = [1, 2, 3, 4, 5] // Example byte array for sourcePublicID
+            let sourcePublicIDOffset = builder.createVector(sourcePublicID)
+            // Create the Event object in the FlatBuffer
+            let action = Arkavo_UserEvent.createUserEvent(
+                &builder,
+                sourceType: .accountProfile,
+                targetType: .streamProfile,
+                sourceIdVectorOffset: sourcePublicIDOffset,
+                targetIdVectorOffset: targetIdVector
+            )
+            // Create the Event object
+            let eventOffset = Arkavo_Event.createEvent(
+                &builder,
+                action: .invite,
+                timestamp: UInt64(Date().timeIntervalSince1970),
+                status: .preparing,
+                dataType: .userevent,
+                dataOffset: action
+            )
+            builder.finish(offset: eventOffset)
+            let serializedEvent = builder.data
+            print("streamInvite: \(builder.data.base64EncodedString())")
+            try sendEvent(serializedEvent)
+        }
+        return stream
+    }
+
+    @MainActor func handle(_ decryptedData: Data, policy _: ArkavoPolicy, nano _: NanoTDF) async throws {
+        _ = try StreamServiceModel.deserialize(from: decryptedData)
+        // TODO: implement
+//        // Check if the stream already exists
+//        if let existingStream = try await fetchExistingStream(publicID: streamServiceModel.publicID) {
+//            // Update existing stream
+        ////            try await updateExistingStream(existingStream, with: streamServiceModel, policy: policy, nano: nano)
+//        } else {
+//            // Create new stream
+        ////            try await createNewStream(from: streamServiceModel, policy: policy, nano: nano)
+//        }
+    }
+
+    enum StreamServiceError: Error {
+        case missingAccountOrProfile
+    }
+}

--- a/Arkavo/Arkavo/Thought.swift
+++ b/Arkavo/Arkavo/Thought.swift
@@ -47,37 +47,6 @@ final class Thought: Identifiable, Codable, @unchecked Sendable {
             Data(SHA256.hash(data: buffer))
         }
     }
-
-    /// decode from hex back to 32 bytes Data
-    public static func decodePublicID(from string: String) throws -> Data {
-        if string.count != 64 {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
-                    codingPath: [],
-                    debugDescription: "Hex string should be 64 characters long."
-                )
-            )
-        }
-        var data = Data()
-        var hexString = string
-        while hexString.count > 0 {
-            let subIndex = hexString.index(hexString.startIndex, offsetBy: 2)
-            let byteString = String(hexString[..<subIndex])
-            hexString = String(hexString[subIndex...])
-
-            if let num = UInt8(byteString, radix: 16) {
-                data.append(num)
-            } else {
-                throw DecodingError.dataCorrupted(
-                    DecodingError.Context(
-                        codingPath: [],
-                        debugDescription: "Invalid hex byte: \(byteString)"
-                    )
-                )
-            }
-        }
-        return data
-    }
 }
 
 extension Thought {

--- a/Arkavo/Arkavo/ThoughtStreamView.swift
+++ b/Arkavo/Arkavo/ThoughtStreamView.swift
@@ -51,7 +51,7 @@ struct ThoughtStreamView: View {
                             VStack {
                                 Spacer()
                                     .frame(height: 100)
-                                Text("No stream profile")
+                                Text("No stream profile for \(viewModel.stream?.profile.name ?? "unknown").")
                                     .font(.headline)
                             }
                         }

--- a/Arkavo/Arkavo/WebSocketManager.swift
+++ b/Arkavo/Arkavo/WebSocketManager.swift
@@ -113,7 +113,9 @@ final class WebSocketManager: ObservableObject {
 
     /// Initiates the WebSocket connection.
     func connect() {
-        lastError = nil
+        DispatchQueue.main.async {
+            self.lastError = nil
+        }
         webSocket?.connect()
         startReconnectTimer()
     }

--- a/Arkavo/Localizable.xcstrings
+++ b/Arkavo/Localizable.xcstrings
@@ -308,6 +308,7 @@
       }
     },
     "No stream profile" : {
+      "extractionState" : "stale",
       "localizations" : {
         "es-US" : {
           "stringUnit" : {
@@ -316,6 +317,9 @@
           }
         }
       }
+    },
+    "No stream profile for %@." : {
+
     },
     "OK" : {
       "localizations" : {

--- a/Arkavo/Localizable.xcstrings
+++ b/Arkavo/Localizable.xcstrings
@@ -153,6 +153,9 @@
         }
       }
     },
+    "Error loading stream: %@" : {
+
+    },
     "ID: %@" : {
       "localizations" : {
         "es-US" : {

--- a/idl/event.fbs
+++ b/idl/event.fbs
@@ -2,28 +2,31 @@ namespace Arkavo;
 
 // Enum to represent action that was performed
 enum Action: byte {
-    join = 0,
-    apply,
-    approve,
-    leave,
-    cache,
-    store,
-    share,
-    invite
+    unused = 0,
+    join = 1,
+    apply = 2,
+    approve = 3,
+    leave = 4,
+    cache = 5,
+    store = 6,
+    share = 7,
+    invite = 8
 }
 
 // Enum to represent the current status of the action
 enum ActionStatus: byte {
-    preparing = 0,
-    fulfilling,
-    fulfilled,
-    failed
+    unused = 0,
+    preparing = 1,
+    fulfilling = 2,
+    fulfilled = 3,
+    failed = 4
 }
 
 // Enum to represent entity types
 enum EntityType: byte {
-    stream_profile = 0,
-    account_profile
+    unused = 0,
+    stream_profile = 1,
+    account_profile = 2
 }
 
 // Table for User Event
@@ -48,7 +51,7 @@ union EventData { UserEvent, CacheEvent }
 // Root Event table
 table Event {
     action: Action;
-    timestamp: ulong;
+    timestamp: ulong;       // time since 1970
     status: ActionStatus;
     data: EventData;
 }

--- a/idl/event.fbs
+++ b/idl/event.fbs
@@ -1,13 +1,17 @@
 namespace Arkavo;
 
-// Enum to represent action types
-enum ActionType: byte {
+// Enum to represent action that was performed
+enum Action: byte {
     join = 0,
     apply,
     approve,
     leave,
-    sendMessage
+    cache,
+    store,
+    share,
+    invite
 }
+
 // Enum to represent the current status of the action
 enum ActionStatus: byte {
     preparing = 0,
@@ -15,23 +19,38 @@ enum ActionStatus: byte {
     fulfilled,
     failed
 }
+
 // Enum to represent entity types
 enum EntityType: byte {
     stream_profile = 0,
     account_profile
 }
 
-table Event {
-  action_type:ActionType;
-}
-// Table for User Action
+// Table for User Event
 table UserEvent {
-    source_type: EntityType;        // Source entity type
-    target_type: EntityType;        // Target entity type
-    source_id: [ubyte];       // Source public ID (array of bytes to represent Data)
-    target_id: [ubyte];       // Target public ID (array of bytes to represent Data)
-    timestamp: ulong;              // Timestamp (using unix timestamp in seconds)
-    status: ActionStatus;          // Action status
+    source_type: EntityType;
+    target_type: EntityType;
+    source_id: [ubyte];       // public ID (array of bytes to represent Data)
+    target_id: [ubyte];       // public ID (array of bytes to represent Data)
+}
+
+// Table for Cache Event
+table CacheEvent {
+    target_id: [ubyte];       // public ID (array of bytes to represent Data)
+    target_payload: [ubyte];  // Binary payload
+    ttl: uint;                // Time-To-Live in seconds
+    one_time_access: bool;    // One-Time Access flag
+}
+
+// Union to represent different event types
+union EventData { UserEvent, CacheEvent }
+
+// Root Event table
+table Event {
+    action: Action;
+    timestamp: ulong;
+    status: ActionStatus;
+    data: EventData;
 }
 
 root_type Event;


### PR DESCRIPTION
FlatBuffers and base58 decoding

Introduced FlatBuffers for efficient binary serialization and added base58 decoding for publicID handling. Modified the application logic to use Data instead of String for publicID, and refactored related classes and methods accordingly.

Resolves #56 