### PR TITLE
Fix Authn redundant

### DIFF
--- a/Arkavo/Arkavo/PostFeedView.swift
+++ b/Arkavo/Arkavo/PostFeedView.swift
@@ -131,7 +131,7 @@ class PostFeedViewModel: ObservableObject {
                     creatorPublicID: thought.metadata.creatorPublicID,
                     thought: thought
                 )
-                print("post: \(post) stream: \(post.streamPublicID.base58EncodedString)")
+//                print("post: \(post) stream: \(post.streamPublicID.base58EncodedString)")
                 await MainActor.run {
                     thoughts.insert(thought, at: 0)
                     posts.insert(post, at: 0)


### PR DESCRIPTION
Ensure account status checks only occur when disconnected, preventing redundant authentication attempts. Additionally, commented out unnecessary debug logging in PostFeedView for cleaner output.

Closes #112 