### PR TITLE
Fix macOS entitlement

### DIFF
--- a/ArkavoCreator/ArkavoCreator/ArkavoCreator.entitlements
+++ b/ArkavoCreator/ArkavoCreator/ArkavoCreator.entitlements
@@ -11,8 +11,6 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
-	<key>com.apple.security.device.audio-video-bridging</key>
-	<true/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.arkavo.ArkavoCreator</string>

--- a/ArkavoCreator/ArkavoCreator/RecordingsLibraryView.swift
+++ b/ArkavoCreator/ArkavoCreator/RecordingsLibraryView.swift
@@ -46,8 +46,8 @@ struct RecordingsLibraryView: View {
                 ProvenanceView(recording: recording)
             }
         }
-        .onAppear {
-            manager.loadRecordings()
+        .task {
+            await manager.loadRecordings()
         }
     }
 
@@ -65,9 +65,11 @@ struct RecordingsLibraryView: View {
                 .foregroundColor(.secondary)
                 .font(.subheadline)
 
-            Button(action: {
-                manager.loadRecordings()
-            }) {
+            Button {
+                Task {
+                    await manager.loadRecordings()
+                }
+            } label: {
                 Image(systemName: "arrow.clockwise")
             }
             .help("Refresh")


### PR DESCRIPTION
## Summary
Fixes the ITMS-90285 App Store rejection error and resolves all deprecation warnings in ArkavoCreator.

## Changes

### 🔧 App Store Rejection Fix (ITMS-90285)
- **Removed** `com.apple.security.device.audio-video-bridging` entitlement from `ArkavoCreator.entitlements`
  - This entitlement is iOS/iPadOS-only and not supported on macOS
  - Retained the correct macOS entitlements for camera and audio access:
    - ✅ `com.apple.security.device.camera`
    - ✅ `com.apple.security.device.audio-input`

### 📱 Modernized AVFoundation APIs
- **Recording.swift**
  - Replaced deprecated `AVAsset(url:)` with `AVURLAsset(url:)`
  - Updated to async `asset.load(.duration)` API (macOS 13.0+)
  - Replaced deprecated `copyCGImage(at:actualTime:)` with async `image(at:)` API (macOS 15.0+)
  - Fixed main actor isolation warnings in notification handlers

- **RecordingsLibraryView.swift**
  - Updated `.onAppear` to `.task` for async operations
  - Properly wrapped async calls in `Task` blocks

## Test Plan
- [x] Build succeeds without errors
- [x] All deprecation warnings resolved
- [x] Camera and microphone permissions still work correctly
- [ ] Manual testing: Recording functionality works as expected
- [ ] Upload to App Store Connect and verify ITMS-90285 error is resolved

## Impact
- **Critical**: Fixes App Store submission blocker
- **Low risk**: Only removes unsupported entitlement and updates to modern APIs
- **Compatibility**: All changes are compatible with macOS 26

🤖 Generated with [Claude Code](https://claude.com/claude-code)