### PR TITLE
Consume ArkavoMediaKit as a remote SwiftPM package (1/4)

### DIFF
--- a/Arkavo/Arkavo.xcodeproj/project.pbxproj
+++ b/Arkavo/Arkavo.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@ E5D86638127846B8989BFA94 /* ConnectedAccountsView.swift in Sources */ = {isa = P
 				DABFC28E2C34F54E00232D79 /* XCRemoteSwiftPackageReference "OpenTDFKit" */,
 				DAEE13852CA0FBEB00DCB5EC /* XCRemoteSwiftPackageReference "flatbuffers" */,
 				DAF7A3A32EC2D80A00A59F0C /* XCLocalSwiftPackageReference "../ArkavoKit" */,
-				DA0000012EF7A00000000001 /* XCLocalSwiftPackageReference "../ArkavoMediaKit" */,
+				DA0000012EF7A00000000001 /* XCRemoteSwiftPackageReference "ArkavoMediaKit" */,
 			);
 			productRefGroup = DAC1F9E42C34DA7000499631 /* Products */;
 			projectDirPath = "";
@@ -1212,10 +1212,6 @@ E5D86638127846B8989BFA94 /* ConnectedAccountsView.swift in Sources */ = {isa = P
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		DA0000012EF7A00000000001 /* XCLocalSwiftPackageReference "../ArkavoMediaKit" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../ArkavoMediaKit;
-		};
 		DAF7A3A32EC2D80A00A59F0C /* XCLocalSwiftPackageReference "../ArkavoKit" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../ArkavoKit;
@@ -1239,12 +1235,20 @@ E5D86638127846B8989BFA94 /* ConnectedAccountsView.swift in Sources */ = {isa = P
 				version = 24.12.23;
 			};
 		};
+		DA0000012EF7A00000000001 /* XCRemoteSwiftPackageReference "ArkavoMediaKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/arkavo-org/ArkavoMediaKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		DA0000022EF7A00000000002 /* ArkavoMediaKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = DA0000012EF7A00000000001 /* XCLocalSwiftPackageReference "../ArkavoMediaKit" */;
+			package = DA0000012EF7A00000000001 /* XCRemoteSwiftPackageReference "ArkavoMediaKit" */;
 			productName = ArkavoMediaKit;
 		};
 		DA34603C2EE4B78B00A1D638 /* ArkavoStore */ = {

--- a/Arkavo/Arkavo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Arkavo/Arkavo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "1cfff8619a82d539e63e8a12599c368d22818716807f8756a56c6ae6f7ada626",
+  "originHash" : "84e3417ef77853d734053b9ffc1375eca408a4a0ca68316097deeed4040b42a2",
   "pins" : [
+    {
+      "identity" : "arkavomediakit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/arkavo-org/ArkavoMediaKit",
+      "state" : {
+        "revision" : "5abc03d923ada26cffe6c3344f88c3f49006b8b5",
+        "version" : "0.1.0"
+      }
+    },
     {
       "identity" : "cryptoswift",
       "kind" : "remoteSourceControl",

--- a/ArkavoCreator/ArkavoCreator.xcodeproj/project.pbxproj
+++ b/ArkavoCreator/ArkavoCreator.xcodeproj/project.pbxproj
@@ -216,7 +216,7 @@
 			packageReferences = (
 				DAVRM0032CFE9B4C00814332 /* XCRemoteSwiftPackageReference "VRMMetalKit" */,
 				REFAC00000000000000000001 /* XCLocalSwiftPackageReference "../ArkavoKit" */,
-				DAHLS0012EE6000000000003 /* XCLocalSwiftPackageReference "../ArkavoMediaKit" */,
+				DAHLS0012EE6000000000003 /* XCRemoteSwiftPackageReference "ArkavoMediaKit" */,
 				DAMC00012EE7000000000003 /* XCLocalSwiftPackageReference "../MuseCore" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -638,10 +638,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		DAHLS0012EE6000000000003 /* XCLocalSwiftPackageReference "../ArkavoMediaKit" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../ArkavoMediaKit;
-		};
 		DAMC00012EE7000000000003 /* XCLocalSwiftPackageReference "../MuseCore" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../MuseCore;
@@ -661,6 +657,14 @@
 				minimumVersion = 0.9.1;
 			};
 		};
+		DAHLS0012EE6000000000003 /* XCRemoteSwiftPackageReference "ArkavoMediaKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/arkavo-org/ArkavoMediaKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -678,7 +682,7 @@
 		};
 		DAHLS0012EE6000000000002 /* ArkavoMediaKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = DAHLS0012EE6000000000003 /* XCLocalSwiftPackageReference "../ArkavoMediaKit" */;
+			package = DAHLS0012EE6000000000003 /* XCRemoteSwiftPackageReference "ArkavoMediaKit" */;
 			productName = ArkavoMediaKit;
 		};
 		DAMC00012EE7000000000002 /* MuseCore */ = {

--- a/ArkavoKit/Package.resolved
+++ b/ArkavoKit/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "112607cbf6d7704cd8f0ce48b7ac4e5aaf140153c415898318789db3b88ad23f",
+  "originHash" : "bdc813a8c86d6303930828b524380068de885e5d2c6a914404ad3e500f5e3198",
   "pins" : [
+    {
+      "identity" : "arkavomediakit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/arkavo-org/ArkavoMediaKit",
+      "state" : {
+        "revision" : "5abc03d923ada26cffe6c3344f88c3f49006b8b5",
+        "version" : "0.1.0"
+      }
+    },
     {
       "identity" : "cryptoswift",
       "kind" : "remoteSourceControl",

--- a/ArkavoKit/Package.swift
+++ b/ArkavoKit/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
         .package(url: "https://github.com/arkavo-org/OpenTDFKit", revision: "d8ffeff"),
         .package(url: "https://github.com/arkavo-org/iroh-swift", from: "0.2.5"),
         .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.19"),
-        .package(path: "../ArkavoMediaKit")
+        .package(url: "https://github.com/arkavo-org/ArkavoMediaKit", from: "0.1.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

ArkavoMediaKit was extracted to its own public repo at [`arkavo-org/ArkavoMediaKit`](https://github.com/arkavo-org/ArkavoMediaKit) (tag [`0.1.0`](https://github.com/arkavo-org/ArkavoMediaKit/releases/tag/0.1.0)). This PR re-points all consumers from the local `../ArkavoMediaKit` relative path to the remote URL pinned `from: "0.1.0"`.

Part of the larger ArkavoCreator extraction sequence (PR 1 of 4):
1. **This PR**: ArkavoMediaKit extracted, consumers re-pointed
2. Next: ArkavoKit extracted to its own public repo
3. Next: ArkavoCreator extracted to a new **private** `arkavo-org/creator` repo
4. Final: cleanup PR removes `ArkavoMediaKit/`, `ArkavoKit/`, `ArkavoCreator/`, `MuseCore/` directories from `arkavo-org/app`

## Why a separate repo

`arkavo-org/app` has no `Package.swift` at the repo root, so it can't be consumed as a remote SwiftPM URL. Three sibling packages (ArkavoKit, ArkavoMediaKit, MuseCore) and one app (ArkavoCreator) all need to leave for ArkavoCreator to live in a private repo without a public-can't-depend-on-private constraint.

## Changes

- `ArkavoKit/Package.swift`: `.package(path: "../ArkavoMediaKit")` → `.package(url: "https://github.com/arkavo-org/ArkavoMediaKit", from: "0.1.0")`
- `Arkavo/Arkavo.xcodeproj/project.pbxproj`: 4 surgical edits (packageReferences entry, local block delete, remote block insert, product-dependency comment)
- `ArkavoCreator/ArkavoCreator.xcodeproj/project.pbxproj`: same 4-edit swap
- `Arkavo/.../Package.resolved` + `ArkavoKit/Package.resolved`: regenerated with remote ArkavoMediaKit @ 0.1.0

## Side effect: OpenTDFKit 4.0.0-beta.1

ArkavoMediaKit's `Package.swift` previously pinned OpenTDFKit by revision (`d8ffeff`). SwiftPM forbids a versioned package from depending on a revision-pinned package, so [`arkavo-org/OpenTDFKit`](https://github.com/arkavo-org/OpenTDFKit) was tagged [`4.0.0-beta.1`](https://github.com/arkavo-org/OpenTDFKit/releases/tag/4.0.0-beta.1) at the same `d8ffeff` commit (matching the maintainer's stated intent in the StandardTDF→TDF rename commit). ArkavoMediaKit now pins `from: "4.0.0-beta.1"`.

This is a pre-release tag in semver terms, so consumers must explicitly opt in (existing OpenTDFKit consumers in this repo continue using the revision pin, unaffected).

## Test plan

- [x] `swift build` in `~/Projects/ArkavoMediaKit/` — clean
- [x] `xcodebuild -project Arkavo/Arkavo.xcodeproj -scheme Arkavo -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' build` → **BUILD SUCCEEDED**
- [ ] **ArkavoCreator scheme is in a transitional state** and not validated on this PR. Its `xcodebuild` resolve fails because of the pre-existing `arkavo-ai/mlx-swift-lm` fork dep (not introduced by this PR). That dep is fixed when ArkavoCreator extracts to its own repo (sequence step 3).

## Notes for reviewer

- `ArkavoMediaKit/` directory **stays in this repo** for now (still resolves locally for any unconverted consumer / for git history before final cleanup)
- The local→remote pbxproj edit pattern mirrors the one used for the now-closed PR #241 (MuseCore). Same 4-edit shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)