### PR TITLE
Consume ArkavoKit as a remote SwiftPM package (2/4)

### DIFF
--- a/Arkavo/Arkavo.xcodeproj/project.pbxproj
+++ b/Arkavo/Arkavo.xcodeproj/project.pbxproj
@@ -617,7 +617,7 @@ E5D86638127846B8989BFA94 /* ConnectedAccountsView.swift in Sources */ = {isa = P
 			packageReferences = (
 				DABFC28E2C34F54E00232D79 /* XCRemoteSwiftPackageReference "OpenTDFKit" */,
 				DAEE13852CA0FBEB00DCB5EC /* XCRemoteSwiftPackageReference "flatbuffers" */,
-				DAF7A3A32EC2D80A00A59F0C /* XCLocalSwiftPackageReference "../ArkavoKit" */,
+				DAF7A3A32EC2D80A00A59F0C /* XCRemoteSwiftPackageReference "ArkavoKit" */,
 				DA0000012EF7A00000000001 /* XCRemoteSwiftPackageReference "ArkavoMediaKit" */,
 			);
 			productRefGroup = DAC1F9E42C34DA7000499631 /* Products */;
@@ -1211,12 +1211,6 @@ E5D86638127846B8989BFA94 /* ConnectedAccountsView.swift in Sources */ = {isa = P
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		DAF7A3A32EC2D80A00A59F0C /* XCLocalSwiftPackageReference "../ArkavoKit" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../ArkavoKit;
-		};
-/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
 		DABFC28E2C34F54E00232D79 /* XCRemoteSwiftPackageReference "OpenTDFKit" */ = {
@@ -1243,6 +1237,14 @@ E5D86638127846B8989BFA94 /* ConnectedAccountsView.swift in Sources */ = {isa = P
 				minimumVersion = 0.1.0;
 			};
 		};
+		DAF7A3A32EC2D80A00A59F0C /* XCRemoteSwiftPackageReference "ArkavoKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/arkavo-org/ArkavoKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1253,7 +1255,7 @@ E5D86638127846B8989BFA94 /* ConnectedAccountsView.swift in Sources */ = {isa = P
 		};
 		DA34603C2EE4B78B00A1D638 /* ArkavoStore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = DAF7A3A32EC2D80A00A59F0C /* XCLocalSwiftPackageReference "../ArkavoKit" */;
+			package = DAF7A3A32EC2D80A00A59F0C /* XCRemoteSwiftPackageReference "ArkavoKit" */;
 			productName = ArkavoStore;
 		};
 		DABFC28F2C34F54E00232D79 /* OpenTDFKit */ = {
@@ -1268,6 +1270,7 @@ E5D86638127846B8989BFA94 /* ConnectedAccountsView.swift in Sources */ = {isa = P
 		};
 		DAF7A3A42EC2D80A00A59F0C /* ArkavoKit */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = DAF7A3A32EC2D80A00A59F0C /* XCRemoteSwiftPackageReference "ArkavoKit" */;
 			productName = ArkavoKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Arkavo/Arkavo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Arkavo/Arkavo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "84e3417ef77853d734053b9ffc1375eca408a4a0ca68316097deeed4040b42a2",
+  "originHash" : "86c5cc75ce61fead93da7194382c7e5efe3de361ba1b93d3d072e6ff6147042f",
   "pins" : [
+    {
+      "identity" : "arkavokit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/arkavo-org/ArkavoKit",
+      "state" : {
+        "revision" : "229b8b54c7ef42c71461717adc43e3cf91ed4a54",
+        "version" : "0.1.0"
+      }
+    },
     {
       "identity" : "arkavomediakit",
       "kind" : "remoteSourceControl",
@@ -33,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/arkavo-org/iroh-swift",
       "state" : {
-        "revision" : "4b3632cba5de6cb47d6c185ac9e569f1e271bd7c",
-        "version" : "0.3.0"
+        "revision" : "e6fa5aaa72f75682074f2cd38adc13e03cf78ece",
+        "version" : "0.4.0"
       }
     },
     {

--- a/ArkavoCreator/ArkavoCreator.xcodeproj/project.pbxproj
+++ b/ArkavoCreator/ArkavoCreator.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				DAVRM0032CFE9B4C00814332 /* XCRemoteSwiftPackageReference "VRMMetalKit" */,
-				REFAC00000000000000000001 /* XCLocalSwiftPackageReference "../ArkavoKit" */,
+				REFAC00000000000000000001 /* XCRemoteSwiftPackageReference "ArkavoKit" */,
 				DAHLS0012EE6000000000003 /* XCRemoteSwiftPackageReference "ArkavoMediaKit" */,
 				DAMC00012EE7000000000003 /* XCLocalSwiftPackageReference "../MuseCore" */,
 			);
@@ -642,10 +642,6 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../MuseCore;
 		};
-		REFAC00000000000000000001 /* XCLocalSwiftPackageReference "../ArkavoKit" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../ArkavoKit;
-		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -665,6 +661,14 @@
 				minimumVersion = 0.1.0;
 			};
 		};
+		REFAC00000000000000000001 /* XCRemoteSwiftPackageReference "ArkavoKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/arkavo-org/ArkavoKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -674,10 +678,12 @@
 		};
 		DA6DEA3D2EE648540042F66F /* ArkavoC2PA */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = REFAC00000000000000000001 /* XCRemoteSwiftPackageReference "ArkavoKit" */;
 			productName = ArkavoC2PA;
 		};
 		DA6DEA3F2EE648540042F66F /* ArkavoKit */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = REFAC00000000000000000001 /* XCRemoteSwiftPackageReference "ArkavoKit" */;
 			productName = ArkavoKit;
 		};
 		DAHLS0012EE6000000000002 /* ArkavoMediaKit */ = {

--- a/ArkavoKit/Package.swift
+++ b/ArkavoKit/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/arkavo-org/OpenTDFKit", revision: "d8ffeff"),
+        .package(url: "https://github.com/arkavo-org/OpenTDFKit", from: "4.0.0-beta.1"),
         .package(url: "https://github.com/arkavo-org/iroh-swift", from: "0.2.5"),
         .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.19"),
         .package(url: "https://github.com/arkavo-org/ArkavoMediaKit", from: "0.1.0")


### PR DESCRIPTION
## Summary

ArkavoKit was extracted to its own public repo at [`arkavo-org/ArkavoKit`](https://github.com/arkavo-org/ArkavoKit) (tag [`0.1.0`](https://github.com/arkavo-org/ArkavoKit)). This PR re-points all consumers from the local `../ArkavoKit` relative path to the remote URL pinned `from: "0.1.0"`.

Stacked on top of #242 (ArkavoMediaKit extraction).

## Changes

- `ArkavoKit/Package.swift`: OpenTDFKit migrated from `revision: "d8ffeff"` to `from: "4.0.0-beta.1"` (required because a versioned package can't depend on a revision-pinned package — same fix landed in `arkavo-org/ArkavoKit` itself)
- `Arkavo/Arkavo.xcodeproj/project.pbxproj`: 5-edit local→remote swap (also added explicit `package = ...` references for the `ArkavoKit` and `ArkavoStore` product dependencies that were previously inferring)
- `ArkavoCreator/ArkavoCreator.xcodeproj/project.pbxproj`: same 5-edit swap (3 product dependencies: `ArkavoKit`, `ArkavoC2PA`, with explicit refs added)
- Both `Package.resolved`s regenerated

## Test plan

- [x] `swift build` in `~/Projects/ArkavoKit/` — clean
- [x] `xcodebuild -project Arkavo/Arkavo.xcodeproj -scheme Arkavo -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' build` → **BUILD SUCCEEDED** (after a derived-data clean — iroh-swift bumped 0.3.0 → 0.4.0 during resolve, header size change tripped a cached `.pcm`)
- [ ] **ArkavoCreator scheme** still in transitional state on this branch — fixed when Creator extracts to its own private repo (PR 3/4)

## Notes for reviewer

- Keeps `ArkavoKit/` directory in this repo for now; deletion is in the final cleanup PR (4/4) along with `ArkavoMediaKit/`, `MuseCore/`, and `ArkavoCreator/`.
- The OpenTDFKit pre-release pin (`4.0.0-beta.1`) is the same one PR #242 introduced via ArkavoMediaKit; consistent across all consumers now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)